### PR TITLE
Fixed username query in the Bash script

### DIFF
--- a/legacy/prof.sh
+++ b/legacy/prof.sh
@@ -5,10 +5,11 @@
 # usage : ./prof.sh [archive.tar.gz]
 
 baseurl="https://prof.fil.univ-lille1.fr/"
-login=login
+echo -n "Username: "
+read -r login
 
 #On récupère le mot de passe
-echo -n Password: 
+echo -n "Password: "
 read -s -r passwd
 echo
 

--- a/legacy/prof.sh
+++ b/legacy/prof.sh
@@ -5,8 +5,16 @@
 # usage : ./prof.sh [archive.tar.gz]
 
 baseurl="https://prof.fil.univ-lille1.fr/"
-echo -n "Username: "
-read -r login
+
+login=""
+
+if [ "$PROF_LOGIN" == "" ]
+then
+	echo -n "Username: "
+	read -r login
+else
+	login=$PROF_LOGIN
+fi
 
 #On récupère le mot de passe
 echo -n "Password: "


### PR DESCRIPTION
The Bash script didn't ask the username, which caused a general problem to access the account on PROF.
This PR fixes this problem by asking the username before asking the password.